### PR TITLE
Added DisableJobsOnDestination flag to Copy-SqlJobServer

### DIFF
--- a/Functions/Copy-SqlJobServer.ps1
+++ b/Functions/Copy-SqlJobServer.ps1
@@ -126,11 +126,14 @@ PROCESS {
 				$migratedjob["$jobobject $agentname"] = "Successfully added"
 				Write-Output "$agentname successfully migrated "
 				} 
-				catch { 
-					if ($_.Exception -like '*duplicate*' -or $_.Exception -like '*exist*') {
+				catch {
+					if ($_.Exception -like '*duplicate*' -or $_.Exception -like '*already exists*') {
 						Write-Output "$agentname exists at destination"
 						$skippedjob.Add("$jobobject $agentname","Skipped. $agentname exists on $destination.") }
-					else { $skippedjob["$jobobject $agentname"] = $_.Exception.Message }
+					else {
+                        $skippedjob["$jobobject $agentname"] = $_.Exception.InnerException.InnerException.Message
+                        Write-Error "$jobobject : $agentname : $($_.Exception.InnerException.InnerException.Message)" 
+                    }
 				}
 			}
 		}


### PR DESCRIPTION
I ran into a scenario where I wanted to copy all of the jobs from server A to server B, but those copied jobs needed to be immediately disabled on server B. Dropped a flag into Copy-SqlJobServer to support this by disabling the job in the SMO object before scripting out for the copy. Figured other people working with Availability Groups may want the same functionality.

I also ran into a situation where job creation on the destination was failing due to the Job's starting database not existing on the server. Since the exception had 'exist' somewhere in there, the command misreported that the job had already been migrated. Tweaked that check and added a Write-Error to get some useful output from this case.