### PR TITLE
Detects server version before CMS migration 

### DIFF
--- a/Functions/Copy-SqlCentralManagementServer.ps1
+++ b/Functions/Copy-SqlCentralManagementServer.ps1
@@ -173,6 +173,11 @@ PROCESS {
 	if (!(Test-SqlSa -SqlServer $sourceserver -SqlCredential $SourceSqlCredential)) { throw "Not a sysadmin on $($sourceserver.name). Quitting." }  
 	if (!(Test-SqlSa -SqlServer $destserver -SqlCredential $DestinationSqlCredential)) { throw "Not a sysadmin on  $($destserver.name). Quitting." }  
 
+	if ($sourceserver.versionMajor -lt 10 -or $destserver.versionMajor -lt 10) {
+		throw "Central Management Server is only supported in SQL Server 2008 and above. Quitting." 
+        
+	}
+	
 	Write-Output "Connecting to Central Management Servers"
 	try { 
 		$fromcmstore = New-Object Microsoft.SqlServer.Management.RegisteredServers.RegisteredServersStore($sourceserver.ConnectionContext.SqlConnectionObject)


### PR DESCRIPTION
If the source or destination server's SQL Server version is less than 2008 (versionMajor less than 10) then Copy-SqlCentralManagementServer will quit.