### PR TITLE
Update Copy-SqlJobServer Job Steps logic

### DIFF
--- a/Functions/Copy-SqlJobServer.ps1
+++ b/Functions/Copy-SqlJobServer.ps1
@@ -122,6 +122,7 @@ PROCESS {
                     $agent.IsEnabled = $False
                 }
 				$sql = $agent.script()	
+				$sql = $sql -replace [regex]::Escape("@server=N'$source'"), "@server=N'$destination'"
 				$null = $destserver.ConnectionContext.ExecuteNonQuery($sql)
 				$migratedjob["$jobobject $agentname"] = "Successfully added"
 				Write-Output "$agentname successfully migrated "


### PR DESCRIPTION
Made a change to replace any instances of hard coded or embedded source SQL Server name in any of the job steps. Testing has shown that the job will fail at creation if it cannot access the hard coded server name. This is more common in older versions of SQL Server, especially SQL Server 2005.