### PR TITLE
Server role not displaying in sync output

### DIFF
--- a/functions/Sync-SqlLoginPermissions.ps1
+++ b/functions/Sync-SqlLoginPermissions.ps1
@@ -166,11 +166,11 @@ https://dbatools.io/Sync-SqlLoginPermissions
 						try
 						{
 							$destrole.DropMember($username)
-							Write-Output "Removed $username from $destrolename server role on $($destserver.name)."
+							Write-Output "Removed $username from $rolename server role on $($destserver.name)."
 						}
 						catch
 						{
-							Write-Warning "Failed to remove $username from $destrolename server role on $($destserver.name)."
+							Write-Warning "Failed to remove $username from $rolename server role on $($destserver.name)."
 							Write-Exception $_
 						}
 					}


### PR DESCRIPTION
When removing a server role, the name of the role was not being displayed in the output, this was due to a misnamed variable.