### PR TITLE
Corrected spaces/tabs, implemented Exclude parameter

### DIFF
--- a/functions/Copy-SqlJob.ps1
+++ b/functions/Copy-SqlJob.ps1
@@ -85,7 +85,7 @@ Shows what would happen if the command were executed using force.
 
 	BEGIN {
 		$jobs = $psboundparameters.Jobs
-		$excludes = $psboundparameters.Excludes
+		$exclude = $psboundparameters.Exclude
 
 		$sourceserver = Connect-SqlServer -SqlServer $Source -SqlCredential $SourceSqlCredential
 		$destserver = Connect-SqlServer -SqlServer $Destination -SqlCredential $DestinationSqlCredential
@@ -104,7 +104,7 @@ Shows what would happen if the command were executed using force.
 		{
 			$jobname = $job.name
 
-			if ($jobs.count -gt 0 -and $jobs -notcontains $jobname -or $excludes -contains $jobname) { continue }
+			if ($jobs.count -gt 0 -and $jobs -notcontains $jobname -or $exclude -contains $jobname) { continue }
 
 			$dbnames = $job.JobSteps.Databasename | Where-Object { $_.length -gt 0 }
 			$missingdb = $dbnames | Where-Object { $destserver.Databases.Name -notcontains $_ }

--- a/functions/DynamicParams.ps1
+++ b/functions/DynamicParams.ps1
@@ -1524,10 +1524,10 @@ Function Get-ParamSqlJobs
 	$attributeCollection.Add($attributes)
 	if ($list) { $attributeCollection.Add($validationset) }
 	$Jobs = New-Object -Type System.Management.Automation.RuntimeDefinedParameter("Jobs", [String[]], $attributeCollection)
-	$Excludes = New-Object -Type System.Management.Automation.RuntimeDefinedParameter("Excludes",[String[]],$attributeCollection)
+	$Exclude = New-Object -Type System.Management.Automation.RuntimeDefinedParameter("Exclude", [String[]], $attributeCollection)
 
 	$newparams.Add("Jobs", $Jobs)
-	$newparams.Add("Excludes", $Excludes)
+	$newparams.Add("Exclude", $Exclude)
 	$server.ConnectionContext.Disconnect()
 
 	return $newparams


### PR DESCRIPTION
Believe I resolved my editor where it will not convert tabs/spaces anymore. Also corrected "Excludes" to "Exclude" parameter per Chrissy's request.