### PR TITLE
Find sql unused indexes validate sql version known issue reset counters

### DIFF
--- a/functions/Find-SqlUnusedIndex.ps1
+++ b/functions/Find-SqlUnusedIndex.ps1
@@ -158,18 +158,18 @@ Will find exact Unused indexes on all user databases
 		}
 
         Write-Output "Attempting to connect to Sql Server.."
-		$sourceserver = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential
+		$server = Connect-SqlServer -SqlServer $SqlServer -SqlCredential $SqlCredential
 	}
 	
 	PROCESS
 	{
 
-        if ($sourceserver.versionMajor -lt 9)
+        if ($server.versionMajor -lt 9)
 		{
 			throw "This function does not support versions lower than SQL Server 2005 (v9)"
 		}
 		
-		$lastrestart = $sourceserver.Databases['tempdb'].CreateDate
+		$lastrestart = $server.Databases['tempdb'].CreateDate
 		$enddate = Get-Date -Date $lastrestart
 		$diffdays = (New-TimeSpan -Start $enddate -End (Get-Date)).Days
 		
@@ -177,6 +177,20 @@ Will find exact Unused indexes on all user databases
 		{
 			throw "The SQL Service was restarted on $lastrestart, which is not long enough for a solid evaluation."
 		}
+        
+        <#
+            Validate if server version is:
+                - sql 2012 and if have SP3 CU3 (Build 6537) or higher
+                - sql 2014 and if have SP2 (Build 5000) or higher
+            If lower this major version but lower build throw message
+        #>
+        if (
+                ($server.VersionMajor -eq 11 -and $server.BuildNumber -lt 6537) `
+            -or ($server.VersionMajor -eq 12 -and $server.BuildNumber -lt 5000)
+           )
+        {
+            throw "This SQL version has a known issue. Rebuilding an index clears any existing row entry from sys.dm_db_index_usage_stats for that index.`r`nPlease refer to connect item: https://connect.microsoft.com/SQLServer/feedback/details/739566/rebuilding-an-index-clears-stats-from-sys-dm-db-index-usage-stats"
+        }
 		
 		if ($diffdays -le 33)
 		{
@@ -194,7 +208,7 @@ Will find exact Unused indexes on all user databases
 
         if ($databases.Count -eq 0)
         {
-            $databases = ($sourceserver.Databases | Where-Object {$_.isSystemObject -eq 0 -and $_.Status -ne "Offline"}).Name
+            $databases = ($server.Databases | Where-Object {$_.isSystemObject -eq 0 -and $_.Status -ne "Offline"}).Name
         }
 
         if ($databases.Count -gt 0)
@@ -207,7 +221,7 @@ Will find exact Unused indexes on all user databases
 
                     $query = $CompletelyUnusedQuery
 
-                    $UnusedIndex = $sourceserver.Databases[$db].ExecuteWithResults($query)
+                    $UnusedIndex = $server.Databases[$db].ExecuteWithResults($query)
 
                     $scriptGenerated = $false
 
@@ -298,6 +312,6 @@ Will find exact Unused indexes on all user databases
 	
 	END
 	{
-		$sourceserver.ConnectionContext.Disconnect()
+		$server.ConnectionContext.Disconnect()
 	}
 }

--- a/functions/Find-SqlUnusedIndex.ps1
+++ b/functions/Find-SqlUnusedIndex.ps1
@@ -182,7 +182,7 @@ Will find exact Unused indexes on all user databases
             Validate if server version is:
                 - sql 2012 and if have SP3 CU3 (Build 6537) or higher
                 - sql 2014 and if have SP2 (Build 5000) or higher
-            If lower this major version but lower build throw message
+            If the major version is the same but the build is lower, throws the message
         #>
         if (
                 ($server.VersionMajor -eq 11 -and $server.BuildNumber -lt 6537) `


### PR DESCRIPTION
Validate 2012/2014 version/builds due known issue

Validate if server version is:
- sql 2012 and if have SP3 CU3 (Build 6537) or higher
- sql 2014 and if have SP2 (Build 5000) or higher
If the major version is the same but the build is lower, throws the message:
"This SQL version has a known issue. Rebuilding an index clears any existing row entry from sys.dm_db_index_usage_stats for that index.
Please refer to connect item: https://connect.microsoft.com/SQLServer/feedback/details/739566/rebuilding-an-index-clears-stats-from-sys-dm-db-index-usage-stats"