### PR TITLE
$rows.count when the number of rows is 0 doesn't work

### DIFF
--- a/functions/SharedFunctions.ps1
+++ b/functions/SharedFunctions.ps1
@@ -821,7 +821,7 @@ Internal function. Ensures login has access on SQL Server.
 		{
 			$rows = $SqlServer.ConnectionContext.ExecuteScalar("EXEC xp_logininfo '$Login'")
 			
-			if ($rows.count -eq 0)
+			if (($rows | Measure-Object).Count -eq 0)
 			{
 				return $false
 			}


### PR DESCRIPTION
When the number of rows returned is 0, the .count method doesn't work,
need to use Measure-Object.