### PR TITLE
Updates to DbaDatabaseOwner functions

### DIFF
--- a/functions/Set-DbaDatabaseOwner.ps1
+++ b/functions/Set-DbaDatabaseOwner.ps1
@@ -132,12 +132,21 @@ Sets database owner to 'sa' on the db1 and db2 databases if their current owner 
 					{
 						Write-Output "Setting database owner for $dbname to $TargetLogin on $servername"
 						# Set database owner to $TargetLogin (default 'sa')
-                        # Database is ReadOnly/Not Updateable, print warning and skip.
+						# Ownership validations checks
+                        
+						#Database is online and accessible 
                         if($db.Status -ne 'Normal'){
-                            Write-Warning "$dbname on $servername is in a  $($db.Sate) state and can not be altered. It will be skipped."
-                        } elseif ($db.IsUpdateable -eq $false) {
+                            Write-Warning "$dbname on $servername is in a  $($db.Sate) state and can not be altered. It will be skipped."						 
+                        } 
+						#Database is updatable, not read-only
+						elseif ($db.IsUpdateable -eq $false) {
 							Write-Warning "$dbname on $servername is not in an updateable state and can not be altered. It will be skipped."
-						} else {
+						} 
+						#Is the login mapped as a user? Logins already mapped in the database can not be the owner
+						elseif ($db.Users.name -contains $TargetLogin) {
+							Write-Warning "$dbname on $servername has $TargetLogin as a mapped user. Mapped users can not be database owners."
+						}
+						else {
                             $db.SetOwner($TargetLogin)
                         }
 					}

--- a/functions/Set-DbaDatabaseOwner.ps1
+++ b/functions/Set-DbaDatabaseOwner.ps1
@@ -136,7 +136,7 @@ Sets database owner to 'sa' on the db1 and db2 databases if their current owner 
                         
 						#Database is online and accessible 
                         if($db.Status -ne 'Normal'){
-                            Write-Warning "$dbname on $servername is in a  $($db.Sate) state and can not be altered. It will be skipped."						 
+                            Write-Warning "$dbname on $servername is in a  $($db.Status) state and can not be altered. It will be skipped."						 
                         } 
 						#Database is updatable, not read-only
 						elseif ($db.IsUpdateable -eq $false) {

--- a/functions/Test-DbaDatabaseOwner.ps1
+++ b/functions/Test-DbaDatabaseOwner.ps1
@@ -130,7 +130,7 @@ that TargetLogin must be a valid security principal that exists on the target se
 				$row = [ordered]@{
 					Server = $server.Name
 					Database = $db.Name
-					DBState = $db.State
+					DBState = $db.Status
 					CurrentOwner = $db.Owner
 					TargetOwner = $TargetLogin
 					OwnerMatch = ($db.owner -eq $TargetLogin)

--- a/functions/Test-DbaDatabaseOwner.ps1
+++ b/functions/Test-DbaDatabaseOwner.ps1
@@ -109,14 +109,13 @@ that TargetLogin must be a valid security principal that exists on the target se
 					Continue
 				}
 			}
-			
+			#use online/available dbs
+            $dbs = $server.Databases | Where-Object {$_.Status -eq 'Normal'}
+
+            #filter database collection based on parameters
 			if ($Databases.Length -gt 0)
 			{
-				$dbs = $server.Databases | Where-Object { $databases -contains $_.Name }
-			}
-			else
-			{
-				$dbs = $server.Databases
+				$dbs = $dbs | Where-Object { $databases -contains $_.Name }
 			}
 			
 			if ($Exclude.Length -gt 0)

--- a/functions/Test-DbaDatabaseOwner.ps1
+++ b/functions/Test-DbaDatabaseOwner.ps1
@@ -110,7 +110,7 @@ that TargetLogin must be a valid security principal that exists on the target se
 				}
 			}
 			#use online/available dbs
-            $dbs = $server.Databases | Where-Object {$_.Status -eq 'Normal'}
+            $dbs = $server.Databases
 
             #filter database collection based on parameters
 			if ($Databases.Length -gt 0)
@@ -130,6 +130,7 @@ that TargetLogin must be a valid security principal that exists on the target se
 				$row = [ordered]@{
 					Server = $server.Name
 					Database = $db.Name
+					DBState = $db.State
 					CurrentOwner = $db.Owner
 					TargetOwner = $TargetLogin
 					OwnerMatch = ($db.owner -eq $TargetLogin)


### PR DESCRIPTION
Added logic to DbaDatabaseOwner functions to exclude any databases that are not online to address issue https://github.com/ctrlbold/dbatools/issues/156.
Added check in Set-DbaDatabase owner for databases in ReadOnly mode. If not updateable, a warning will be thrown and database skipped.